### PR TITLE
fix: resolve Windows UTF-8 encoding issue for international characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3] - 2025-12-28
+
+### Fixed
+- **Windows UTF-8 Encoding**: Fixed international character corruption on Windows systems
+  - Subprocess I/O now explicitly uses UTF-8 encoding instead of system default code page
+  - Sets `PYTHONUTF8=1` and `PYTHONIOENCODING=utf-8` environment variables for Windows
+  - Properly encodes input as UTF-8 bytes and decodes output with error handling
+  - Resolves issue #1 where Chinese and other non-ASCII characters were corrupted
+
+### Added
+- **Enhanced Windows CLI Detection**: Improved Codex CLI path detection on Windows
+  - Added `.ps1` to supported Windows executable extensions
+  - Added fallback checks for common Windows installation paths:
+    - `%LOCALAPPDATA%\Programs\codex\codex.exe`
+    - `%APPDATA%\npm\codex.cmd`
+    - `%USERPROFILE%\.cargo\bin\codex.exe`
+- **Improved Error Diagnostics**: Better error messages for Windows users
+  - Added `FileNotFoundError` specific handling with actionable guidance
+  - Error responses now include platform information for debugging
+  - Clear instructions to verify `codex --version` in Command Prompt
+
+### Changed
+- **Error Metadata**: All error responses now include `platform` and `exception_type` fields
+- **Documentation**: Updated module docstring to mention Windows UTF-8 compatibility
+
+## [1.2.2] - 2025-09-09
+
+### Fixed
+- **Windows Compatibility**: Added platform-specific subprocess handling for Windows
+  - Removed `start_new_session=True` which is not supported on Windows
+  - Added Windows executable detection (.exe, .bat, .cmd extensions)
+  - Created `_run_codex_command()` helper for cross-platform execution
+
+### Added
+- **Platform Detection Utilities**: `_is_windows()` and `_get_codex_command()` functions
+- **CI/CD Improvements**: Updated GitHub Actions for PyPI Trusted Publishing
+
 ## [1.2.1] - 2025-09-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `%LOCALAPPDATA%\Programs\codex\codex.exe`
     - `%APPDATA%\npm\codex.cmd`
     - `%USERPROFILE%\.cargo\bin\codex.exe`
+  - New `_build_codex_exec_command()` helper that uses the detected path
+  - PowerShell scripts (.ps1) are now executed via `powershell -ExecutionPolicy Bypass -File`
 - **Improved Error Diagnostics**: Better error messages for Windows users
   - Added `FileNotFoundError` specific handling with actionable guidance
   - Error responses now include platform information for debugging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codex-bridge"
-version = "1.2.2"
+version = "1.2.3"
 description = "Lightweight MCP server bridging Claude Code to OpenAI Codex via official CLI"
 readme = "README.md"
 license = "MIT"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,9 +1,9 @@
 """
 MCP Codex Assistant - Simple CLI bridge to OpenAI Codex.
-Version 1.2.2 - Windows compatibility fix for cross-platform support.
+Version 1.2.3 - Windows UTF-8 encoding fix for international character support.
 """
 
 from .mcp_server import main
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 __all__ = ["main"]


### PR DESCRIPTION
## Summary

- Fixes Windows UTF-8 encoding issue where international characters (Chinese, etc.) were corrupted
- Improves Windows CLI detection with additional paths and extensions
- Enhances error diagnostics with platform-specific messages

## Problem

Issue #1 reported that UTF-8 characters passed through MCP were corrupted on Windows. This was caused by the subprocess module using the system's default code page (e.g., `cp1252`, `cp936`) instead of UTF-8.

## Solution

### UTF-8 Encoding Fix
- Use explicit UTF-8 encoding for subprocess I/O on Windows
- Set `PYTHONUTF8=1` and `PYTHONIOENCODING=utf-8` environment variables
- Encode input as UTF-8 bytes and decode output with `errors='replace'`

### Enhanced Windows CLI Detection
- Added `.ps1` to Windows executable extensions
- Added fallback checks for common Windows installation paths:
  - `%LOCALAPPDATA%\Programs\codex\codex.exe`
  - `%APPDATA%\npm\codex.cmd`
  - `%USERPROFILE%\.cargo\bin\codex.exe`

### Improved Error Diagnostics
- Added `FileNotFoundError` specific handling
- Error responses now include `platform` and `exception_type` fields
- Clear instructions for Windows users to verify installation

## Test Plan

- [x] Python syntax validation passes (`python -m py_compile`)
- [x] All version numbers updated to 1.2.3
- [x] CHANGELOG.md updated with v1.2.2 and v1.2.3 entries
- [ ] Windows user verification (requires feedback from @bianoengpeng)

## Files Changed

- `src/mcp_server.py` - Core fix for UTF-8 encoding and error handling
- `src/__init__.py` - Version bump to 1.2.3
- `pyproject.toml` - Version bump to 1.2.3
- `CHANGELOG.md` - Added v1.2.2 and v1.2.3 entries

Closes #1